### PR TITLE
rename template blocks to be unique

### DIFF
--- a/explorer/templates/explorer/base.html
+++ b/explorer/templates/explorer/base.html
@@ -13,7 +13,7 @@
 
 <body>
     <div id="wrap">
-        {% block navbar %}
+        {% block sql_explorer_navbar %}
             <div class="navbar navbar-default navbar-static-top" role="navigation">
               <div class="container">
                 <div class="navbar-header">
@@ -21,7 +21,7 @@
                 </div>
                 <div class="navbar-collapse collapse">
                   <ul class="nav navbar-nav">
-                    {% block navlinks %}{% endblock %}
+                    {% block sql_explorer_navlinks %}{% endblock %}
                   </ul>
                 </div><!--/.nav-collapse -->
               </div>
@@ -29,11 +29,11 @@
         {% endblock %}
         <div class="container">
           <div class="starter-template">
-          {% block content %}{% endblock %}
+          {% block sql_explorer_content %}{% endblock %}
           </div>
         </div>
     </div>
-    {% block footer %}
+    {% block sql_explorer_footer %}
         <div id="footer" style="padding-top:20px;">
             <div class="container">
                 <p class="text-muted">
@@ -45,7 +45,7 @@
     {% endblock %}
     <script src="//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.5.2/underscore-min.js"></script>
     <script src="//netdna.bootstrapcdn.com/bootstrap/3.0.3/js/bootstrap.min.js"></script>
-    {% block scripts %}{% endblock %}
+    {% block sql_explorer_scripts %}{% endblock %}
 </body>
 
 </html>

--- a/explorer/templates/explorer/play.html
+++ b/explorer/templates/explorer/play.html
@@ -1,13 +1,13 @@
 {% extends "explorer/base.html" %}
 
-{% block navlinks %}
+{% block sql_explorer_navlinks %}
     {% if can_change %}
       <li><a href="../new/">New Query</a></li>
       <li class="active"><a href="#">Playground</a></li>
     {% endif %}
 {% endblock %}
 
-{% block content %}
+{% block sql_explorer_content %}
 <div class="row">
     <div id="query_area" class="col-md-12">
         <h2>Playground</h2>
@@ -46,7 +46,7 @@
 
 {% endblock %}
 
-{% block scripts %}
+{% block sql_explorer_scripts %}
     {% include 'explorer/preview_pane_scripts.html' %}
     {% include 'explorer/sql_editor_scripts.html' %}
     <script>

--- a/explorer/templates/explorer/query.html
+++ b/explorer/templates/explorer/query.html
@@ -1,7 +1,7 @@
 {% extends "explorer/base.html" %}
 {% load url from future %}
 
-{% block navlinks %}
+{% block sql_explorer_navlinks %}
     {% if can_change %}
       <li{% if not query %} class="active" {% endif %}><a href="../new/">New Query</a></li>
       <li><a href="../play/">Playground</a></li>
@@ -9,7 +9,7 @@
     {% if query %}<li class="active"><a href="">Query Detail</a></li>{% endif %}
 {% endblock %}
 
-{% block content %}
+{% block sql_explorer_content %}
 <div class="row">
     <div id="query_area" class="col-md-12">
         <h2 style="padding-bottom: 20px">{% if query %}{{ query.title }}{% else %}New Query{% endif %}</h2>
@@ -89,7 +89,7 @@
 {% include 'explorer/preview_pane.html' %}
 {% endblock %}
 
-{% block scripts %}
+{% block sql_explorer_scripts %}
     {% include 'explorer/preview_pane_scripts.html' %}
     {% include 'explorer/sql_editor_scripts.html' %}
     <script>

--- a/explorer/templates/explorer/query_confirm_delete.html
+++ b/explorer/templates/explorer/query_confirm_delete.html
@@ -1,6 +1,6 @@
 {% extends "explorer/base.html" %}
 
-{% block content %}
+{% block sql_explorer_content %}
     <form method="post">{% csrf_token %}
         <div class="alert alert-info">
             Are you sure you want to delete "{{ object.title }}" ?

--- a/explorer/templates/explorer/query_list.html
+++ b/explorer/templates/explorer/query_list.html
@@ -1,13 +1,13 @@
 {% extends "explorer/base.html" %}
 
-{% block navlinks %}
+{% block sql_explorer_navlinks %}
     {% if can_change %}
       <li><a href="new/">New Query</a></li>
       <li><a href="play/">Playground</a></li>
     {% endif %}
 {% endblock %}
 
-{% block content %}
+{% block sql_explorer_content %}
     <h3>{{ title }}</h3>
     <table class="table table-striped">
         <thead>

--- a/explorer/templates/explorer/schema.html
+++ b/explorer/templates/explorer/schema.html
@@ -1,7 +1,7 @@
 {% extends "explorer/base.html" %}
 
-{% block navbar %}{% endblock %}
-{% block content %}
+{% block sql_explorer_navbar %}{% endblock %}
+{% block sql_explorer_content %}
 
     <h4 style="text-align: center;">Schema</h4>
 
@@ -27,4 +27,4 @@
     {% endfor %}
 
 {% endblock %}
-{% block footer %}{% endblock %}
+{% block sql_explorer_footer %}{% endblock %}


### PR DESCRIPTION
Using sql explorer within another project may result in template block naming conflicts. Prefixing the block names should resolve this issue.

Please release a new pyPI package after merge.
