### PR TITLE
Showing an error when the data type is different from what mysql expects

### DIFF
--- a/explorer/models.py
+++ b/explorer/models.py
@@ -48,7 +48,7 @@ class Query(models.Model):
             return [], [], None, MSG_FAILED_BLACKLIST
         try:
             return execute_and_fetch_query(self.final_sql())
-        except DatabaseError, e:
+        except (DatabaseError, Warning), e:
             return [], [], None, str(e)
 
     def available_params(self):


### PR DESCRIPTION
If the data type given in a where clause was different than what mysql expected, it would raise a Warning and eventually 500 in the application. This would also make the query view unusable, you were not able to go to the view and the edit the query to fix it.

eg.

``` sql
SELECT 
    email
FROM
    user_table
WHERE
    joined_date > 'some-non-date-value';
```

Earlier This would raise a 500.

Now this will be an error in the query view. 
