### PR TITLE
Limit chart data by user specified number of rows

### DIFF
--- a/explorer/app_settings.py
+++ b/explorer/app_settings.py
@@ -137,6 +137,7 @@ S3_DESTINATION = getattr(settings, "EXPLORER_S3_DESTINATION", '')
 UNSAFE_RENDERING = getattr(settings, "EXPLORER_UNSAFE_RENDERING", False)
 
 EXPLORER_CHARTS_ENABLED = getattr(settings, "EXPLORER_CHARTS_ENABLED", False)
+EXPLORER_LIMIT_CHART_DATA_ROWS = getattr(settings, "EXPLORER_LIMIT_CHART_DATA_ROWS", False)
 
 # If set to True will autorun queries when viewed which is the historical behavior
 # Default to True if not set in order to be backwards compatible

--- a/explorer/views/utils.py
+++ b/explorer/views/utils.py
@@ -63,8 +63,8 @@ def query_viewmodel(request, query, title=None, form=None, message=None,
         'unsafe_rendering': app_settings.UNSAFE_RENDERING,
         'fullscreen_params': fullscreen_params.urlencode(),
         'charts_enabled': app_settings.EXPLORER_CHARTS_ENABLED,
-        'pie_chart_svg': get_pie_chart(res) if app_settings.EXPLORER_CHARTS_ENABLED and has_valid_results else None,
-        'line_chart_svg': get_line_chart(res) if app_settings.EXPLORER_CHARTS_ENABLED and has_valid_results else None,
+        'pie_chart_svg': get_pie_chart(res, rows=rows) if app_settings.EXPLORER_CHARTS_ENABLED and has_valid_results else None,
+        'line_chart_svg': get_line_chart(res, rows=rows) if app_settings.EXPLORER_CHARTS_ENABLED and has_valid_results else None,
         'is_favorite': is_favorite
     }
     return ret


### PR DESCRIPTION
@marksweb Hey, I was wondering if this is something you might be interested in?

We use this package and found it useful to graph only the result data as displayed and limited by the user specified row limit.

I added a setting for consideration for backward compatibility for existing users. If that's cool with you I'll incorporate this into the docs also.

I'll also add tests if you're cool with the changes in this PR.