### PR TITLE
automatically expand everything on search

### DIFF
--- a/explorer/src/js/query-list.js
+++ b/explorer/src/js/query-list.js
@@ -9,6 +9,11 @@ function searchFocus() {
         searchElement.focus();
     }
 }
+function expandAll() {
+    document.querySelectorAll('.collapse').forEach(function(element){
+       element.classList.add('show');
+    });
+}
 export function setupQueryList() {
 
     document.querySelectorAll('.query_favorite_toggle').forEach(function (element) {
@@ -17,7 +22,10 @@ export function setupQueryList() {
 
     let options = {
         valueNames: ['sort-name', 'sort-created', 'sort-created', 'sort-last-run', 'sort-run-count', 'sort-connection'],
-        handlers: {'updated': [searchFocus]}
+        handlers: {'updated': [searchFocus],
+                   'searchStart': [expandAll]},
+        searchDelay: 250,
+        searchColumns: ['sort-name']
     };
     new List('queries', options);
 

--- a/explorer/templates/explorer/query_list.html
+++ b/explorer/templates/explorer/query_list.html
@@ -69,18 +69,18 @@
             </thead>
             <tbody class="list">
                 {% for object in object_list %}
-                    <tr {% if object.is_in_category %}class="collapse {{object.collapse_target}}"{% endif %}>
+                    <tr {% if object.is_in_category %}class="collapse {{object.collapse_target}}" data-bs-config='{"delay":0}'{% endif %}>
                         {% if object.is_header %}
                             <td colspan="100">
                                 <strong>
                                     <span data-bs-toggle="collapse" style="cursor: pointer;" data-bs-target=".{{object.collapse_target}}">
-                                        {{ object.title }} ({{ object.count }})
+                                        <i class="bi-plus-circle"></i> {{ object.title }} ({{ object.count }})
                                     </span>
                                 </strong>
                             </td>
                         {% else %}
-                            <td class="sort-name{% if object.is_in_category %} indented{% endif %}">
-                                <a href="{% url 'query_detail' object.id %}">{{ object.title }}</a>
+                            <td class="sort-name">
+                                <a href="{% url 'query_detail' object.id %}"{% if object.is_in_category %} class="ms-3"{% endif %}>{{ object.title }}</a>
                             </td>
                             <td class="sort-created">{{ object.created_at|date:"m/d/y" }}
                                 {% if object.created_by_user %}


### PR DESCRIPTION
Addresses #464 and #658 

The search was in fact working for un-expanded queries, but of course they were unexpanded, so they were visually hidden. What this does is, on completion of a search, any results are forced to be shown. The result is that after clearing the search field, anything that previously matched is now expanded, but that seems fine.