### PR TITLE
5.3.0

### DIFF
--- a/explorer/assistant/utils.py
+++ b/explorer/assistant/utils.py
@@ -40,7 +40,7 @@ def extract_response(r):
 
 def table_schema(db_connection, table_name):
     schema = schema_info(db_connection)
-    s = [table for table in schema if table[0] == table_name]
+    s = [table for table in schema if table[0].lower() == table_name.lower()]
     if len(s):
         return s[0][1]
 

--- a/explorer/tests/test_assistant.py
+++ b/explorer/tests/test_assistant.py
@@ -16,7 +16,8 @@ from explorer.assistant.utils import (
     ROW_SAMPLE_SIZE,
     build_prompt,
     get_relevant_few_shots,
-    get_relevant_annotation
+    get_relevant_annotation,
+    table_schema
 )
 
 from explorer.assistant.models import TableDescription
@@ -211,8 +212,23 @@ class TestPromptContext(TestCase):
         self.assertEqual(ret, "col1 | col2\nval1 | val2")
 
     def test_schema_info_from_table_names(self):
-        from explorer.assistant.utils import table_schema
         ret = table_schema(default_db_connection(), "explorer_query")
+        expected = [
+            ("id", "AutoField"),
+            ("title", "CharField"),
+            ("sql", "TextField"),
+            ("description", "TextField"),
+            ("created_at", "DateTimeField"),
+            ("last_run_date", "DateTimeField"),
+            ("created_by_user_id", "IntegerField"),
+            ("snapshot", "BooleanField"),
+            ("connection", "CharField"),
+            ("database_connection_id", "IntegerField"),
+            ("few_shot", "BooleanField")]
+        self.assertEqual(ret, expected)
+
+    def test_schema_info_from_table_names_case_invariant(self):
+        ret = table_schema(default_db_connection(), "EXPLORER_QUERY")
         expected = [
             ("id", "AutoField"),
             ("title", "CharField"),


### PR DESCRIPTION
- Handle case issues on selected tables for assisntant
- issue #675 - fail gracefully when building the schema if a particular table cant be accessed by the connection