### PR TITLE
Gracefully handle NotSupportedError during schema introspection

### DIFF
--- a/explorer/schema.py
+++ b/explorer/schema.py
@@ -1,5 +1,5 @@
 from django.core.cache import cache
-from django.db import ProgrammingError
+from django.db import NotSupportedError, ProgrammingError
 
 from explorer.app_settings import (
     EXPLORER_SCHEMA_EXCLUDE_TABLE_PREFIXES,
@@ -108,7 +108,7 @@ def build_schema_info(db_connection):
                     cursor, table_name
                 )
             # Issue 675. A connection maybe not have permissions to access some tables in the DB.
-            except ProgrammingError:
+            except (NotSupportedError, ProgrammingError):
                 continue
 
             td = []


### PR DESCRIPTION
In certain circumstances, a django.db.utils.NotSupportedError can be thrown during schema introspection. If this happens, the exception is unhandled and Django returns a 500 response instead of displaying query results.

To reproduce requires:

- Postgresql running in recovery mode (typically a hot standby server). This can be [simulated](https://dba.stackexchange.com/questions/80620/how-to-simulate-postgresql-recovery-mode) without a hot standby server
- An unlogged table on the primary (`ALTER TABLE table_name SET UNLOGGED`)
- Attempt to execute a query (e.g. `SELECT 1`) against the standby server and receive a 500 error page

Exception detail:
```
NotSupportedError
cannot access temporary or unlogged relations during recovery
```

The issue can be worked around by specifying the affected tables in the `EXPLORER_SCHEMA_EXCLUDE_TABLE_PREFIXES` setting, but this change makes a workaround unnecessary.