### PR TITLE
Regex validate query title and remove exception text from email.

### DIFF
--- a/explorer/models.py
+++ b/explorer/models.py
@@ -7,6 +7,7 @@ from django.core.exceptions import ValidationError
 from django.db import DatabaseError, models, transaction
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
+from django.core.validators import RegexValidator
 
 from explorer import app_settings
 from explorer.telemetry import Stat, StatNames
@@ -27,7 +28,13 @@ logger = logging.getLogger(__name__)
 
 
 class Query(models.Model):
-    title = models.CharField(max_length=255)
+    title = models.CharField(max_length=255, validators=[
+        RegexValidator(
+            r"^[a-zA-Z0-9\s\.\-\_]+$",
+            "Title contains invalid characters. "
+            "Only alphanumeric characters, spaces, periods, hyphens, and underscores are allowed."
+        )
+    ])
     sql = models.TextField(blank=False, null=False)
     description = models.TextField(blank=True)
     created_by_user = models.ForeignKey(

--- a/explorer/tasks.py
+++ b/explorer/tasks.py
@@ -47,7 +47,7 @@ def execute_query(query_id, email_address):
         msg = f"Download results:\n\r{url}"
     except Exception as e:
         subj = f"[SQL Explorer] Error running report {q.title}"
-        msg = f"Error: {e}\nPlease contact an administrator"
+        msg = "Please contact an administrator."
         logger.exception(f"{subj}: {e}")
     send_mail(subj, msg, app_settings.FROM_EMAIL, [email_address])
 


### PR DESCRIPTION
Since the query.title is included in the email subject and body, add validation to ensure only it is only populated with legal characters. This will prevent a bad actor from sending malicious reports (containing malicious links etc) to users.

Also remove the exception text from any emails. This will prevent any unintentional leaking of sensitive information. 