### PR TITLE
fix #694 - append '/' to VITE_OUTPUT_DIR if missing

### DIFF
--- a/explorer/templatetags/vite.py
+++ b/explorer/templatetags/vite.py
@@ -9,6 +9,8 @@ from explorer import app_settings, get_version
 register = template.Library()
 
 VITE_OUTPUT_DIR = staticfiles_storage.url("explorer/")
+if not VITE_OUTPUT_DIR.endswith("/"):
+    VITE_OUTPUT_DIR += "/"
 VITE_DEV_DIR = "explorer/src/"
 VITE_SERVER_HOST = getattr(settings, "VITE_SERVER_HOST", "localhost")
 VITE_SERVER_PORT = getattr(settings, "VITE_SERVER_PORT", "5173")


### PR DESCRIPTION
This is needed for AZURE that does not output "/" at the end from the staticfiles_storage.url() method