### PR TITLE
Added S3 object parameters config parameter similar to django-s3-storage 

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -287,6 +287,32 @@ To be able to access your s3 objects in all regions through presigned urls, expl
    EXPLORER_S3_SIGNATURE_VERSION = 's3v4'
 
 
+S3 parameters on objects
+************************
+
+Default: ``{'ServerSideEncryption': 'AES256'}``
+
+Use this to set parameters on all objects.
+
+To view a full list of possible parameters (there are many) see the `Boto3 docs for uploading files`_; an incomplete list includes: ``CacheControl``, ``SSEKMSKeyId``, ``StorageClass``, ``Tagging`` and ``Metadata``.
+
+.. code-block:: python
+
+   # --- SERVER SIDE ENCRYPTION SETTINGS ---
+   # Use AES256 for SSE-S3
+   EXPLORER_S3_OBJECT_PARAMETERS = {
+       'ServerSideEncryption': 'AES256',
+       'CacheControl': 'max-age=86400',
+       'ContentDisposition': 'attachment',
+   }
+
+   # ALTERNATIVE: For SSE-KMS
+   EXPLORER_S3_OBJECT_PARAMETERS = {
+       'ServerSideEncryption': 'aws:kms',
+       'SSEKMSKeyId': 'your-kms-key-id', # Optional
+   }
+
+
 From email
 **********
 

--- a/explorer/app_settings.py
+++ b/explorer/app_settings.py
@@ -122,6 +122,7 @@ ENABLE_TASKS = getattr(settings, "EXPLORER_TASKS_ENABLED", False)
 S3_ACCESS_KEY = getattr(settings, "EXPLORER_S3_ACCESS_KEY", None)
 S3_SECRET_KEY = getattr(settings, "EXPLORER_S3_SECRET_KEY", None)
 S3_BUCKET = getattr(settings, "EXPLORER_S3_BUCKET", None)
+S3_OBJECT_PARAMETERS = getattr(settings, "EXPLORER_S3_OBJECT_PARAMETERS", {"ServerSideEncryption": "AES256"})
 S3_LINK_EXPIRATION: int = getattr(settings, "EXPLORER_S3_LINK_EXPIRATION", 3600)
 FROM_EMAIL = getattr(
     settings, "EXPLORER_FROM_EMAIL", "django-sql-explorer@example.com"

--- a/explorer/ee/db_connections/utils.py
+++ b/explorer/ee/db_connections/utils.py
@@ -4,6 +4,7 @@ import hashlib
 import sqlite3
 import io
 
+from explorer import app_settings
 
 def default_db_connection():
     from explorer.ee.db_connections.models import DatabaseConnection
@@ -18,7 +19,7 @@ def default_db_connection_id():
 def upload_sqlite(db_bytes, path):
     from explorer.utils import get_s3_bucket
     bucket = get_s3_bucket()
-    bucket.put_object(Key=path, Body=db_bytes, ServerSideEncryption="AES256")
+    bucket.put_object(Key=path, Body=db_bytes, **app_settings.S3_OBJECT_PARAMETERS)
 
 
 # Aliases have the user_id appended to them so that if two users upload files with the same name


### PR DESCRIPTION
Added S3 object parameters config parameter similar to django-s3-storage: **EXPLORER_S3_OBJECT_PARAMETERS**. The default is still `{'ServerSideEncryption': 'AES256'}`.

Fix for issue #707 